### PR TITLE
Set HTMLTextView's padding to 0. Put cell's elements in stackView.

### DIFF
--- a/HackerNews.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/HackerNews.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/onevcat/Kingfisher.git",
         "state": {
           "branch": null,
-          "revision": "2f9d171f17869768f6dbec1d039b851e2503af35",
-          "version": "5.12.0"
+          "revision": "2a10bf41da75599a9f8e872dbd44fe0155a2e00c",
+          "version": "5.15.8"
         }
       },
       {

--- a/HackerNews/ViewControllers/StoryViewController.swift
+++ b/HackerNews/ViewControllers/StoryViewController.swift
@@ -23,11 +23,11 @@ class StoryViewController: UIViewController {
         let tableView = UITableView()
         tableView.backgroundColor = .systemBackground
         tableView.separatorStyle = .none
-        tableView.rowHeight = UITableView.automaticDimension
-        tableView.estimatedRowHeight = 100
+        tableView.estimatedRowHeight = 500
         tableView.translatesAutoresizingMaskIntoConstraints = false
         tableView.register(CommentCell.self, forCellReuseIdentifier: "CommentCell")
         tableView.register(StoryViewHeaderCell.self, forCellReuseIdentifier: "StoryViewHeaderCell")
+        tableView.allowsSelection = false
         return tableView
     }()
 
@@ -198,10 +198,6 @@ extension StoryViewController: UITableViewDelegate, UITableViewDataSource {
         } else {
             self.title = story.title
         }
-    }
-    
-    func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
-        return UITableView.automaticDimension
     }
     
 }

--- a/HackerNews/Views/CommentCell.swift
+++ b/HackerNews/Views/CommentCell.swift
@@ -15,38 +15,13 @@ protocol CommentCellDelegate: class {
 class CommentCell: UITableViewCell {
     
     weak var delegate: CommentCellDelegate?
-    private var userAndTimeLabelLeadingAnchoConstraint = NSLayoutConstraint()
-    private var htmlViewLeadingAnchorConstraint = NSLayoutConstraint()
+
     private var tier: Int = 0
-    
-    private let dummyVerticalLeftSeparator: UIView = {
-        let view = UIView()
-        view.translatesAutoresizingMaskIntoConstraints = false
-        view.backgroundColor = .clear
-        view.widthAnchor.constraint(equalToConstant: 1).isActive = true
-        return view
-    }()
-    
-    private let dummyVerticalRightSeparator: UIView = {
-       let view = UIView()
-        view.translatesAutoresizingMaskIntoConstraints = false
-        view.backgroundColor = .clear
-        view.widthAnchor.constraint(equalToConstant: 0).isActive = true
-        return view
-    }()
     
     private let htmlView: HTMLView = {
         let htmlView = HTMLView(frame: CGRect.zero)
         htmlView.translatesAutoresizingMaskIntoConstraints = false
         return htmlView
-    }()
-    
-    private let verticalSeparatorStackView: UIStackView = {
-        let stackView = UIStackView()
-        stackView.translatesAutoresizingMaskIntoConstraints = false
-        stackView.axis = .horizontal
-        stackView.distribution = .equalSpacing
-        return stackView
     }()
     
     private let topHorizontalSeparatorView: UIView = {
@@ -59,45 +34,64 @@ class CommentCell: UITableViewCell {
     private let userAndTimeLabel: UILabel = {
         let label = UILabel()
         label.translatesAutoresizingMaskIntoConstraints = false
-        label.backgroundColor = UIColor.clear
-        label.lineBreakMode = .byWordWrapping
-        label.numberOfLines = 0
+        label.numberOfLines = 1
         label.font = UIFont.preferredFont(forTextStyle: .callout)
         label.textColor = .secondaryLabel
         return label
     }()
-    
+
+    private let vStack: UIStackView = {
+        let stackView = UIStackView()
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        stackView.axis = .vertical
+        stackView.alignment = .leading
+        stackView.distribution = .fill
+        return stackView
+    }()
+
+    private let indentLineStack: UIStackView = {
+        let stackView = UIStackView()
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        stackView.axis = .horizontal
+        stackView.alignment = .fill
+        stackView.distribution = .equalSpacing
+        return stackView
+    }()
+
+    private lazy var indentLineStackWidthAnchor: NSLayoutConstraint = {
+        let constraint = indentLineStack.widthAnchor.constraint(equalToConstant: 0)
+        constraint.isActive = true
+        return constraint
+    }()
+
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
+
         selectionStyle = .none
         backgroundColor = .systemBackground
         htmlView.delegate = self
-        contentView.addSubview(userAndTimeLabel)
-        contentView.addSubview(htmlView)
+
+        vStack.addArrangedSubview(userAndTimeLabel)
+        vStack.addArrangedSubview(htmlView)
+
+        contentView.addSubview(indentLineStack)
+        contentView.addSubview(vStack)
         contentView.addSubview(topHorizontalSeparatorView)
-        contentView.addSubview(verticalSeparatorStackView)
-        
+
         NSLayoutConstraint.activate([
-            userAndTimeLabel.topAnchor.constraint(equalTo: contentView.layoutMarginsGuide.topAnchor),
-            userAndTimeLabel.trailingAnchor.constraint(equalTo: contentView.layoutMarginsGuide.trailingAnchor),
-            userAndTimeLabel.bottomAnchor.constraint(equalTo: htmlView.topAnchor),
-            htmlView.leadingAnchor.constraint(equalTo: userAndTimeLabel.leadingAnchor),
-            htmlView.trailingAnchor.constraint(equalTo: contentView.layoutMarginsGuide.trailingAnchor),
-            htmlView.bottomAnchor.constraint(equalTo: contentView.layoutMarginsGuide.bottomAnchor),
-            topHorizontalSeparatorView.topAnchor.constraint         (equalTo: contentView.topAnchor),
-            topHorizontalSeparatorView.heightAnchor.constraint      (equalToConstant: 2),
-            topHorizontalSeparatorView.leadingAnchor.constraint     (equalTo: contentView.leadingAnchor),
-            topHorizontalSeparatorView.trailingAnchor.constraint    (equalTo: contentView.trailingAnchor),
-            verticalSeparatorStackView.topAnchor.constraint         (equalTo: contentView.topAnchor),
-            verticalSeparatorStackView.leadingAnchor.constraint     (equalTo: contentView.leadingAnchor),
-            verticalSeparatorStackView.trailingAnchor.constraint    (equalTo: userAndTimeLabel.leadingAnchor),
-            verticalSeparatorStackView.bottomAnchor.constraint      (equalTo: contentView.bottomAnchor)
-            ])
-        
-        userAndTimeLabelLeadingAnchoConstraint = userAndTimeLabel.leadingAnchor.constraint(equalTo: contentView.layoutMarginsGuide.leadingAnchor)
-        htmlViewLeadingAnchorConstraint = htmlView.leadingAnchor.constraint(equalTo: contentView.layoutMarginsGuide.leadingAnchor)
-        userAndTimeLabelLeadingAnchoConstraint.isActive = true
-        htmlViewLeadingAnchorConstraint.isActive = true
+            indentLineStack.topAnchor.constraint(equalTo: contentView.topAnchor),
+            indentLineStack.leadingAnchor.constraint(equalTo: contentView.layoutMarginsGuide.leadingAnchor),
+            indentLineStack.bottomAnchor.constraint(equalTo: contentView.bottomAnchor),
+            vStack.topAnchor.constraint(equalTo: contentView.layoutMarginsGuide.topAnchor),
+            vStack.trailingAnchor.constraint(equalTo: contentView.layoutMarginsGuide.trailingAnchor),
+            vStack.bottomAnchor.constraint(equalTo: contentView.layoutMarginsGuide.bottomAnchor),
+            vStack.leadingAnchor.constraint(equalTo: indentLineStack.trailingAnchor),
+            topHorizontalSeparatorView.topAnchor.constraint(equalTo: contentView.topAnchor),
+            topHorizontalSeparatorView.heightAnchor.constraint(equalToConstant: 2),
+            topHorizontalSeparatorView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
+            topHorizontalSeparatorView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
+        ])
+
     }
     
     required init?(coder: NSCoder) {
@@ -107,43 +101,44 @@ class CommentCell: UITableViewCell {
     func configure(with comment: Comment) {
         htmlView.html = comment.text
         userAndTimeLabel.text = comment.info
-        self.tier = comment.tier
+        tier = comment.tier
         topHorizontalSeparatorView.isHidden = comment.tier != 0
-        addSeparatorView(for: comment.tier)
-        self.layoutIfNeeded()
-    }
-    
-    private func addSeparatorView(for tier: Int) {
-        verticalSeparatorStackView.addArrangedSubview(dummyVerticalLeftSeparator)
-        if tier > 0 {
-            for _ in 1...tier {
-                let separatorView = UIView()
-                separatorView.translatesAutoresizingMaskIntoConstraints = false
-                separatorView.backgroundColor = .systemGray4
-                separatorView.widthAnchor.constraint(equalToConstant: 1).isActive = true
-                verticalSeparatorStackView.addArrangedSubview(separatorView)
-            }
-        }
-        verticalSeparatorStackView.addArrangedSubview(dummyVerticalRightSeparator)
-    }
-    
-    override func prepareForReuse() {
-        super.prepareForReuse()
-        htmlView.html = nil
-        userAndTimeLabel.text = nil
-        verticalSeparatorStackView.arrangedSubviews.forEach {
-            $0.removeFromSuperview()
-        }
+        addIndentLineView(withTier: comment.tier)
     }
     
     override func layoutSubviews() {
         super.layoutSubviews()
-        let leftMargin = Int(contentView.directionalLayoutMargins.leading)
-        let indent = CGFloat(self.tier * leftMargin)
-        userAndTimeLabelLeadingAnchoConstraint.constant = indent
-        htmlViewLeadingAnchorConstraint.constant = indent
+
+        indentLineStackWidthAnchor.constant = CGFloat(tier) * contentView.directionalLayoutMargins.leading
     }
-    
+
+    private func addIndentLineView(withTier tier: Int) {
+        if tier > 0 {
+            for _ in 1...tier {
+                indentLineStackWidthAnchor.constant += 1
+                let separatorView = UIView()
+                separatorView.translatesAutoresizingMaskIntoConstraints = false
+                separatorView.backgroundColor = .systemGray4
+                separatorView.widthAnchor.constraint(equalToConstant: 1).isActive = true
+                indentLineStack.addArrangedSubview(separatorView)
+            }
+            let dummyView = UIView()
+            dummyView.translatesAutoresizingMaskIntoConstraints = false
+            dummyView.widthAnchor.constraint(equalToConstant: 0).isActive = true
+            indentLineStack.addArrangedSubview(dummyView)
+        }
+    }
+
+    override func prepareForReuse() {
+        super.prepareForReuse()
+
+        htmlView.html = nil
+        userAndTimeLabel.text = nil
+        indentLineStack.arrangedSubviews.forEach {
+            $0.removeFromSuperview()
+        }
+    }
+
 }
 
 extension CommentCell: HTMLViewDelegate {

--- a/HackerNews/Views/HTMLView.swift
+++ b/HackerNews/Views/HTMLView.swift
@@ -29,8 +29,7 @@ class HTMLView: UIView {
         textView.isScrollEnabled = false
         textView.isEditable = false
         textView.backgroundColor = .clear
-        textView.textContainer.lineBreakMode = .byWordWrapping
-        textView.textContainer.maximumNumberOfLines = 0
+        textView.textContainer.lineFragmentPadding = 0
         return textView
     }()
         
@@ -40,10 +39,10 @@ class HTMLView: UIView {
         self.addSubview(htmlTextView)
 
         NSLayoutConstraint.activate([
-        htmlTextView.topAnchor.constraint(equalTo: self.topAnchor),
-        htmlTextView.leadingAnchor.constraint(equalTo: self.leadingAnchor),
-        htmlTextView.trailingAnchor.constraint(equalTo: self.trailingAnchor, constant: -10),
-        htmlTextView.bottomAnchor.constraint(equalTo: self.bottomAnchor)
+            htmlTextView.topAnchor.constraint(equalTo: topAnchor),
+            htmlTextView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            htmlTextView.trailingAnchor.constraint(equalTo: trailingAnchor),
+            htmlTextView.bottomAnchor.constraint(equalTo: bottomAnchor)
         ])
     }
     


### PR DESCRIPTION
Fixed text alignment between userAndTimeLabel and htmlView's textView by setting HTMLTextView's padding to 0.

Also worked on issue disappearing of userAndTimeLabel and htmlView make awkward blank space when tableView is scrolled fast.  Flickering is also observed. 
This problem is not solved yet. 

https://user-images.githubusercontent.com/50497605/129617465-a5c5301e-899c-4e40-8204-c84edd6bf4ad.mov

